### PR TITLE
Fix tests by adding ansi-wl-pprint to depends

### DIFF
--- a/nibblestring.cabal
+++ b/nibblestring.cabal
@@ -49,3 +49,4 @@ Test-Suite test-nibblestring
                     , test-framework-hunit
                     , HUnit
                     , containers
+                    , ansi-wl-pprint


### PR DESCRIPTION
Added the package `ansi-wl-pprint` to the build dependencies of the test suite as required to build tests.
